### PR TITLE
Removed leftover 'break' statement.

### DIFF
--- a/PHPExcel/Classes/PHPExcel/Calculation/Functions.php
+++ b/PHPExcel/Classes/PHPExcel/Calculation/Functions.php
@@ -578,7 +578,6 @@ class PHPExcel_Calculation_Functions {
 				return 4;
 		} elseif(is_array($value)) {
 				return 64;
-				break;
 		} elseif(is_string($value)) {
 			//	Errors
 			if ((strlen($value) > 0) && ($value{0} == '#')) {


### PR DESCRIPTION
I guess a switch-structure was converted to ifs and elses, and
this break statement was not removed.

It does not cause any harm in php 5.x, but php 7 does not like this.
